### PR TITLE
Escape xml special chars from zefania bible text-nodes

### DIFF
--- a/src/module/bible/zefania-bible.cpp
+++ b/src/module/bible/zefania-bible.cpp
@@ -18,6 +18,7 @@ this program; if not, see <http://www.gnu.org/licenses/>.
 #include "CLucene.h"
 #include "CLucene/clucene-config.h"
 #include <QXmlStreamReader>
+#include <QTextDocument>
 using namespace lucene::analysis;
 using namespace lucene::index;
 using namespace lucene::queryParser;
@@ -605,7 +606,7 @@ Verse ZefaniaBible::readVerse()
             break;
 
         if(m_xml->tokenType() == QXmlStreamReader::Characters) {
-            out += m_xml->text();
+            out += Qt::escape(m_xml->text().toString());
         } else if(cmp(m_xml->name(), "STYLE") || m_xml->name() == "st") {
             out += pharseStyle();
         } else if(cmp(m_xml->name(), "NOTE")) {


### PR DESCRIPTION
QXmlStreamReader returns escaped special chars unescaped.
e.g &lt; found in the xml will be returned as <.

In Elberfelder bibles [1], text additions for better understanding are
enclosed in <>:
Since webkit interprets them (e.g.<foo>) as html tag,
they need to be escaped, to be actually shown on screen.

[1] http://www.die-bibel.de/online-bibeln/elberfelder-bibel/bibeltext/bibel/text/lesen/stelle/55/10004/19999/ch/
